### PR TITLE
reorganize wasm unit testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "types": "./pkg/orchestrion_js.d.ts",
   "scripts": {
     "build": "wasm-pack build --target nodejs --release -- --features wasm",
-    "test": "node ./tests/tests.mjs"
+    "test": "node ./tests/wasm/tests.mjs"
   },
   "dependencies": {
     "wasm-pack": "^0.13.1"

--- a/tests/wasm/testdata/expected.mjs
+++ b/tests/wasm/testdata/expected.mjs
@@ -1,37 +1,4 @@
-import { create } from "../pkg/orchestrion_js.js";
-import * as assert from "node:assert";
-
-const instrumentor = create([
-    {
-        channelName: "up:constructor",
-        module: { name: "one", versionRange: ">=1", filePath: "index.js" },
-        functionQuery: { className: "Up" },
-    },
-    {
-        channelName: "up:fetch",
-        module: { name: "one", versionRange: ">=1", filePath: "index.js" },
-        functionQuery: {
-            className: "Up",
-            methodName: "fetch",
-            kind: "Sync",
-        },
-    },
-]);
-
-const matchedTransforms = instrumentor.getTransformer(
-    "one",
-    "1.0.0",
-    "index.js",
-);
-
-assert.ok(matchedTransforms);
-
-const output = matchedTransforms.transform(
-    "export class Up { constructor() {console.log('constructor')} fetch() {console.log('fetch')} }",
-    true,
-);
-
-assert.strictEqual(output, `import { tracingChannel as tr_ch_apm_tracingChannel } from "diagnostics_channel";
+import { tracingChannel as tr_ch_apm_tracingChannel } from "diagnostics_channel";
 const tr_ch_apm$up:fetch = tr_ch_apm_tracingChannel("orchestrion:one:up:fetch");
 const tr_ch_apm$up:constructor = tr_ch_apm_tracingChannel("orchestrion:one:up:constructor");
 export class Up {
@@ -71,4 +38,3 @@ export class Up {
         });
     }
 }
-`);

--- a/tests/wasm/testdata/original.mjs
+++ b/tests/wasm/testdata/original.mjs
@@ -1,0 +1,9 @@
+export class Up {
+	constructor() {
+		console.log('constructor')
+	}
+
+	fetch() {
+		console.log('fetch')
+	}
+}

--- a/tests/wasm/tests.mjs
+++ b/tests/wasm/tests.mjs
@@ -1,0 +1,35 @@
+import { create } from "../../pkg/orchestrion_js.js";
+import * as assert from "node:assert";
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+const instrumentor = create([
+    {
+        channelName: "up:constructor",
+        module: { name: "one", versionRange: ">=1", filePath: "index.js" },
+        functionQuery: { className: "Up" },
+    },
+    {
+        channelName: "up:fetch",
+        module: { name: "one", versionRange: ">=1", filePath: "index.js" },
+        functionQuery: {
+            className: "Up",
+            methodName: "fetch",
+            kind: "Sync",
+        },
+    },
+]);
+
+const matchedTransforms = instrumentor.getTransformer(
+    "one",
+    "1.0.0",
+    "index.js",
+);
+
+assert.ok(matchedTransforms);
+
+const original = await fs.readFile(path.join(import.meta.dirname, './testdata/original.mjs'))
+const output = matchedTransforms.transform(original.toString('utf8'), true);
+
+const expected = await fs.readFile(path.join(import.meta.dirname, './testdata/expected.mjs'))
+assert.strictEqual(output, expected.toString('utf8'));


### PR DESCRIPTION
This PR re-organizes the wasm module instrumentation unit test to move the inlined strings out to fixture files.