### PR TITLE
chore: Rename npm module for temporary publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Orchestion-JS
+# `@apm-js-collab/code-transformer`
 
-Orchestrion is a library for instrumenting Node.js libraries at build or load time.
+This is a library for instrumenting Node.js libraries at build or load time.
 
 It provides `VisitMut` implementations for SWC's AST nodes, which can be used to insert tracing code into matching functions. 
 It can be used in SWC plugins, or anything else that mutates JavaScript ASTs using SWC.
 
-Orchestrion can also be built as a JavaScript module, which can be used from Node.js.
+`@apm-js-collab/code-transformer` is built as a JavaScript module, which can be used from Node.js.
 
 To build the JavaScript module:
 - Ensure you have [Rust installed](https://www.rust-lang.org/tools/install)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # `@apm-js-collab/code-transformer`
 
+This is a temporary fork of [`DataDog/orchestrion-js`](https://github.com/DataDog/orchestrion-js/). We intend all changes to be upstreamed to the original repository, 
+
 This is a library for instrumenting Node.js libraries at build or load time.
 
 It provides `VisitMut` implementations for SWC's AST nodes, which can be used to insert tracing code into matching functions. 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@apm-js-collab/code-transformer",
   "version": "0.1.1",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/apm-js-collab/orchestrion-js.git"
+  },
   "files": [
     "./pkg/orchestrion_js_bg.wasm",
     "./pkg/orchestrion_js.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "orchestrion-js",
-  "version": "0.1.0",
+  "name": "@apm-js-collab/code-transformer",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "files": [
     "./pkg/orchestrion_js_bg.wasm",


### PR DESCRIPTION
I've already published this here although I haven't tested it yet!
https://www.npmjs.com/package/@apm-js-collab/code-transformer