### PR TITLE
fix: Ensure `channel_name` doesn't cause invalid identifiers

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,14 @@ impl InstrumentationConfig {
             function_query,
         }
     }
+
+    #[must_use]
+    pub fn get_identifier_name(&self) -> String {
+        self.channel_name
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+            .collect()
+    }
 }
 
 #[cfg_attr(

--- a/src/instrumentation.rs
+++ b/src/instrumentation.rs
@@ -63,7 +63,7 @@ impl Instrumentation {
     }
 
     fn create_tracing_channel(&self) -> Stmt {
-        let ch_str = ident!(format!("tr_ch_apm${}", self.config.channel_name));
+        let ch_str = ident!(format!("tr_ch_apm${}", self.config.get_identifier_name()));
         let channel_string = Expr::Lit(Lit::Str(Str {
             span: Span::default(),
             value: format!(
@@ -95,10 +95,11 @@ impl Instrumentation {
 
         let traced_fn = self.new_fn(original_body);
 
-        let ch_ident = ident!(format!("tr_ch_apm${}", &self.config.channel_name));
+        let id_name = self.config.get_identifier_name();
+        let ch_ident = ident!(format!("tr_ch_apm${}", &id_name));
         let trace_ident = ident!(format!(
             "tr_ch_apm${}.{}",
-            &self.config.channel_name,
+            &id_name,
             self.config.function_query.kind().tracing_operator()
         ));
 
@@ -120,8 +121,9 @@ impl Instrumentation {
 
         let original_stmts = std::mem::take(&mut body.stmts);
 
-        let ch_ident = ident!(format!("tr_ch_apm${}", &self.config.channel_name));
-        let ctx_ident = ident!(format!("tr_ch_apm_ctx${}", &self.config.channel_name));
+        let id_name = self.config.get_identifier_name();
+        let ch_ident = ident!(format!("tr_ch_apm${}", &id_name));
+        let ctx_ident = ident!(format!("tr_ch_apm_ctx${}", &id_name));
         let mut try_catch = quote!(
             "try {
                 if ($ch.hasSubscribers) {

--- a/tests/class_method_cjs/mod.rs
+++ b/tests/class_method_cjs/mod.rs
@@ -7,7 +7,7 @@ fn class_method_cjs() {
         file!(),
         false,
         Config::new_single(InstrumentationConfig::new(
-            "Undici_fetch",
+            "Undici:fetch",
             test_module_matcher(),
             FunctionQuery::class_method("Undici", "fetch", FunctionKind::Async),
         )),

--- a/tests/class_method_cjs/test.js
+++ b/tests/class_method_cjs/test.js
@@ -4,7 +4,7 @@
  **/
 const Undici = require('./instrumented.js');
 const { assert, getContext } = require('../common/preamble.js');
-const context = getContext('orchestrion:undici:Undici_fetch');
+const context = getContext('orchestrion:undici:Undici:fetch');
 (async () => {
   const undici = new Undici;
   const result = await undici.fetch('https://example.com');

--- a/tests/wasm/testdata/expected.mjs
+++ b/tests/wasm/testdata/expected.mjs
@@ -1,29 +1,29 @@
 import { tracingChannel as tr_ch_apm_tracingChannel } from "diagnostics_channel";
-const tr_ch_apm$up:fetch = tr_ch_apm_tracingChannel("orchestrion:one:up:fetch");
-const tr_ch_apm$up:constructor = tr_ch_apm_tracingChannel("orchestrion:one:up:constructor");
+const tr_ch_apm$up_fetch = tr_ch_apm_tracingChannel("orchestrion:one:up:fetch");
+const tr_ch_apm$up_constructor = tr_ch_apm_tracingChannel("orchestrion:one:up:constructor");
 export class Up {
     constructor(){
-        const tr_ch_apm_ctx$up:constructor = {
+        const tr_ch_apm_ctx$up_constructor = {
             arguments
         };
         try {
-            if (tr_ch_apm$up:constructor.hasSubscribers) {
-                tr_ch_apm$up:constructor.start.publish(tr_ch_apm_ctx$up:constructor);
+            if (tr_ch_apm$up_constructor.hasSubscribers) {
+                tr_ch_apm$up_constructor.start.publish(tr_ch_apm_ctx$up_constructor);
             }
             console.log('constructor');
         } catch (tr_ch_err) {
-            if (tr_ch_apm$up:constructor.hasSubscribers) {
-                tr_ch_apm_ctx$up:constructor.error = tr_ch_err;
+            if (tr_ch_apm$up_constructor.hasSubscribers) {
+                tr_ch_apm_ctx$up_constructor.error = tr_ch_err;
                 try {
-                    tr_ch_apm_ctx$up:constructor.self = this;
+                    tr_ch_apm_ctx$up_constructor.self = this;
                 } catch (refErr) {}
-                tr_ch_apm$up:constructor.error.publish(tr_ch_apm_ctx$up:constructor);
+                tr_ch_apm$up_constructor.error.publish(tr_ch_apm_ctx$up_constructor);
             }
             throw tr_ch_err;
         } finally{
-            if (tr_ch_apm$up:constructor.hasSubscribers) {
-                tr_ch_apm_ctx$up:constructor.self = this;
-                tr_ch_apm$up:constructor.end.publish(tr_ch_apm_ctx$up:constructor);
+            if (tr_ch_apm$up_constructor.hasSubscribers) {
+                tr_ch_apm_ctx$up_constructor.self = this;
+                tr_ch_apm$up_constructor.end.publish(tr_ch_apm_ctx$up_constructor);
             }
         }
     }
@@ -31,8 +31,8 @@ export class Up {
         const traced = ()=>{
             console.log('fetch');
         };
-        if (!tr_ch_apm$up:fetch.hasSubscribers) return traced();
-        return tr_ch_apm$up:fetch.traceSync(traced, {
+        if (!tr_ch_apm$up_fetch.hasSubscribers) return traced();
+        return tr_ch_apm$up_fetch.traceSync(traced, {
             arguments,
             self: this
         });


### PR DESCRIPTION
As reported by @bizob2828,

`channel_name` was used to create JavaScript identifiers but it can contain invalid characters. This PR uses an identifier-safe string when creating identifiers!

This was not picked up by the Rust tests because they all used channel names that were valid identifiers. This haas been changed.