### PR TITLE
chore: Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- fix: Handle `module.exports = class Foo` when locating classes (#7)
+
 ## 0.2.0
 
 - fix: Ensure `channel_name` doesn't cause invalid JavaScript identifiers (#4)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apm-js-collab/code-transformer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This has already been released:
https://www.npmjs.com/package/@apm-js-collab/code-transformer/v/0.3.0