### PR TITLE
feat: Allow `unknown` module type

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -3,6 +3,32 @@ use std::path::PathBuf;
 use swc::config::IsModule;
 use wasm_bindgen::prelude::*;
 
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "lowercase")
+)]
+#[cfg_attr(
+    feature = "wasm",
+    derive(tsify::Tsify),
+    tsify(into_wasm_abi, from_wasm_abi)
+)]
+pub enum ModuleType {
+    ESM,
+    CJS,
+    Unknown,
+}
+
+impl From<ModuleType> for IsModule {
+    fn from(value: ModuleType) -> Self {
+        match value {
+            ModuleType::ESM => IsModule::Bool(true),
+            ModuleType::CJS => IsModule::Bool(false),
+            ModuleType::Unknown => IsModule::Unknown,
+        }
+    }
+}
+
 #[wasm_bindgen]
 pub struct InstrumentationMatcher(Instrumentor);
 
@@ -33,10 +59,9 @@ pub struct Transformer(InstrumentationVisitor);
 #[wasm_bindgen]
 impl Transformer {
     #[wasm_bindgen]
-    pub fn transform(&mut self, contents: &str, is_module: bool) -> Result<String, JsError> {
-        let is_module = IsModule::Bool(is_module);
+    pub fn transform(&mut self, contents: &str, is_module: ModuleType) -> Result<String, JsError> {
         self.0
-            .transform(contents, is_module)
+            .transform(contents, is_module.into())
             .map_err(|e| JsError::new(&e.to_string()))
     }
 }

--- a/tests/wasm/tests.mjs
+++ b/tests/wasm/tests.mjs
@@ -29,13 +29,13 @@ const matchedTransforms = instrumentor.getTransformer(
 assert.ok(matchedTransforms);
 
 const original = await fs.readFile(path.join(import.meta.dirname, './testdata/original.mjs'))
-const output = matchedTransforms.transform(original.toString('utf8'), 'unknown');
+const output = matchedTransforms.transform(original.toString('utf8'), 'esm');
 
 const expected = await fs.readFile(path.join(import.meta.dirname, './testdata/expected.mjs'))
 assert.strictEqual(output, expected.toString('utf8'));
 
 const originalCjs = await fs.readFile(path.join(import.meta.dirname, './testdata/original-cjs.js'))
-const outputCjs = matchedTransforms.transform(originalCjs.toString('utf8'), 'unknown');
+const outputCjs = matchedTransforms.transform(originalCjs.toString('utf8'), 'cjs');
 
 
 const expectedCjs = await fs.readFile(path.join(import.meta.dirname, './testdata/expected-cjs.js'))

--- a/tests/wasm/tests.mjs
+++ b/tests/wasm/tests.mjs
@@ -29,13 +29,13 @@ const matchedTransforms = instrumentor.getTransformer(
 assert.ok(matchedTransforms);
 
 const original = await fs.readFile(path.join(import.meta.dirname, './testdata/original.mjs'))
-const output = matchedTransforms.transform(original.toString('utf8'), true);
+const output = matchedTransforms.transform(original.toString('utf8'), 'unknown');
 
 const expected = await fs.readFile(path.join(import.meta.dirname, './testdata/expected.mjs'))
 assert.strictEqual(output, expected.toString('utf8'));
 
 const originalCjs = await fs.readFile(path.join(import.meta.dirname, './testdata/original-cjs.js'))
-const outputCjs = matchedTransforms.transform(originalCjs.toString('utf8'), false);
+const outputCjs = matchedTransforms.transform(originalCjs.toString('utf8'), 'unknown');
 
 
 const expectedCjs = await fs.readFile(path.join(import.meta.dirname, './testdata/expected-cjs.js'))
@@ -44,5 +44,5 @@ assert.strictEqual(outputCjs, expectedCjs.toString('utf8'));
 const noMatch = await fs.readFile(path.join(import.meta.dirname, './testdata/no-match.mjs'));
 
 assert.throws(() => {
-    matchedTransforms.transform(noMatch.toString('utf8'), true);
+    matchedTransforms.transform(noMatch.toString('utf8'), 'unknown');
 }, { message: "Failed to find injection points for: [\"constructor\", \"fetch\"]" });


### PR DESCRIPTION
Previously you needed to tell the JavaScript API whether the file you're transforming is ESM or CJS. While trying to use the published library in a bundler plugin, I found that you don't always know the module type and detecting this is non-trivial. 

The swc `isModule` type actually has an unknown option where swc does module type detection. I have change the API so it's now possible to select `esm`, `cjs` or alternatively `unknown` and let swc detect it.