### PR TITLE
fix: `wasm-pack` should be in `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "wasm-pack build --target nodejs --release -- --features wasm",
     "test": "node ./tests/wasm/tests.mjs"
   },
-  "dependencies": {
+  "devDependencies": {
     "wasm-pack": "^0.13.1"
   },
   "volta": {


### PR DESCRIPTION
This is only required for building and isn't needed at runtime!