### PR TITLE
fix: `versionRange` TypeScript definition

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 #[derive(Debug, Clone)]
 pub struct ModuleMatcher {
     pub name: String,
+    #[tsify(type = "string")]
     pub version_range: Range,
     pub file_path: PathBuf,
 }


### PR DESCRIPTION
- Closes #34