### PR TITLE
ci: Fix `release-please` github token permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,9 @@ on:
 
 permissions:
   id-token: write  # Required for OIDC
-  contents: read
+  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   release-please:


### PR DESCRIPTION
Should have followed the docs. The github token needs permissions to open pull requests!