### PR TITLE
ci: `release-please` needs a Github token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ secrets.RELEASE_PLEASE_GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
The `GITHUB_TOKEN` supplied by default to GHA can create pull requests but CI workflows will not run automatically in those newly created PRs.

Adding a proper token fixes this. This token was created in the `apm-js-collab` org and is scope to all repositories so it can be reused.

You can work around this issue by closing and reopening the PR but this is a pain.
