### PR TITLE
feat: Load wasm lazily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ tests/*/instrumented.*
 pkg/
 node_modules/
 package-lock.json
+index.js
+index.d.ts

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,31 @@
+import type { InstrumentationConfig, InstrumentationMatcher, create as internalCreate } from './pkg/orchestrion_js';
+
+// ./pkg/orchestrion_js.js has a side effect of loading the wasm binary. 
+// We only want that if the library is actually used!
+let cachedCreate: typeof internalCreate | undefined;
+
+/**
+ * Create a new instrumentation matcher from an array of instrumentation configs.
+ */
+export function create(configs: InstrumentationConfig[], dc_module?: string | null): InstrumentationMatcher {
+    if (!cachedCreate) {
+        cachedCreate = require('./pkg/orchestrion_js.js').create;
+    }
+
+    if (cachedCreate === undefined) {
+        throw new Error("Failed to load '@apm-js-collab/code-transformer'");
+    }
+
+    return cachedCreate(configs, dc_module);
+}
+
+export type {
+    FunctionKind,
+    FunctionQuery,
+    InstrumentationConfig,
+    InstrumentationMatcher,
+    ModuleMatcher,
+    ModuleType,
+    TransformOutput,
+    Transformer,
+} from './pkg/orchestrion_js'

--- a/package.json
+++ b/package.json
@@ -10,17 +10,21 @@
     "./pkg/orchestrion_js_bg.wasm",
     "./pkg/orchestrion_js.js",
     "./pkg/orchestrion_js.d.ts",
+    "./index.js",
+    "./index.d.ts",
     "LICENSE",
     "NOTICE"
   ],
-  "main": "./pkg/orchestrion_js.js",
-  "types": "./pkg/orchestrion_js.d.ts",
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "scripts": {
-    "build": "wasm-pack build --target nodejs --release -- --features wasm",
+    "build": "wasm-pack build --target nodejs --release -- --features wasm && yarn build:wrapper",
+    "build:wrapper": "tsc index.ts --declaration --module commonjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@types/node": "^18.0.0",
     "source-map": "^0.7.6",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4",

--- a/tests/wasm/tests.test.mjs
+++ b/tests/wasm/tests.test.mjs
@@ -1,4 +1,4 @@
-import { create } from "../../pkg/orchestrion_js.js";
+import { create } from "../../index.js";
 import { describe, test, expect } from "vitest";
 import tsc from "typescript";
 import { SourceMapConsumer } from "source-map";

--- a/yarn.lock
+++ b/yarn.lock
@@ -254,6 +254,13 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
+"@types/node@^18.0.0":
+  version "18.19.124"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.124.tgz#6f49e4fab8274910691a900e8a14316cbf3c7a31"
+  integrity sha512-hY4YWZFLs3ku6D2Gqo3RchTd9VRCcrjqp/I0mmohYeUVA5Y8eCXKJEasHxLAJVZRJuQogfd1GiJ9lgogBgKeuQ==
+  dependencies:
+    undici-types "~5.26.4"
+
 "@vitest/expect@3.2.4":
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.2.4.tgz#8362124cd811a5ee11c5768207b9df53d34f2433"
@@ -710,6 +717,11 @@ typescript@^5.8.3:
   version "5.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
   integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 vite-node@3.2.4:
   version "3.2.4"


### PR DESCRIPTION
- Ref #44

I noticed that the auto-generated code has large side-effects which will impact app startup time. We should only be loading the wasm if and when the library is actually used.

This PR adds a wrapper which means the wasm only gets loaded the first time the `create` method is called.