### PR TITLE
feat: Inline wasm binary

### DIFF
--- a/inline-binary.js
+++ b/inline-binary.js
@@ -1,0 +1,10 @@
+const { readFileSync, writeFileSync } = require("node:fs");
+
+const wasm = readFileSync("./pkg/orchestrion_js_bg.wasm");
+const wasmBase64 = wasm.toString("base64");
+
+let js = readFileSync("./pkg/orchestrion_js.js", "utf8");
+
+js = js.replace(/const path[\S\s]+readFileSync\(path\)/, `const bytes = Buffer.from('${wasmBase64}', 'base64')`);
+
+writeFileSync("./pkg/orchestrion_js.js", js);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "url": "https://github.com/apm-js-collab/orchestrion-js.git"
   },
   "files": [
-    "./pkg/orchestrion_js_bg.wasm",
     "./pkg/orchestrion_js.js",
     "./pkg/orchestrion_js.d.ts",
     "LICENSE",
@@ -17,6 +16,7 @@
   "types": "./pkg/orchestrion_js.d.ts",
   "scripts": {
     "build": "wasm-pack build --target nodejs --release -- --features wasm",
+    "postbuild": "node inline-binary.js",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
- Ref #44

No bundlers support resolving the wasm binary with the default code:
```js
const path = require('path').join(__dirname, 'orchestrion_js_bg.wasm');
const bytes = require('fs').readFileSync(path);
```
That means if code gets bundled, the wasm is missing and this library cannot be used.

This PR inlines the wasm binary as a base64 string which works even if the code is bundled:

```js
const bytes = Buffer.from('AGFzbQE...snip...', 'base64');
```

## Downsides?
- The binary (and therefore the module) is about 33% larger
- Maybe less performant loading this way as it goes through the JavaScript parser?