### PR TITLE
feat: Add support for matching export alias

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "orchestrion-js"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.84.1"
+rust-version = "1.87.0"
 license = "Apache-2.0"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -79,6 +79,32 @@ matcher.free();
 transformer.free();
 ```
 
+### Export Aliases
+
+When a module re-exports a function or class under a different name using
+`export { local as exported }`, you can target the **exported** name in your
+`FunctionQuery` by setting `isExportAlias: true`. The transformer will resolve
+the alias to the local declaration before matching.
+
+For example, given:
+
+```js
+function f(url) { return fetch(url); }
+export { f as fetchAliased };
+```
+
+You can target `fetchAliased` in your config:
+
+```js
+const instrumentation = {
+    channelName: "my-channel",
+    module: { name: "my-module", versionRange: ">=1.0.0", filePath: "./index.mjs" },
+    functionQuery: { functionName: "fetchAliased", kind: "Async", isExportAlias: true },
+};
+```
+
+This also works for class exports (e.g., `export { MyClass as PublicClass }`).
+
 ### API Reference
 
 ```ts
@@ -91,20 +117,21 @@ type FunctionKind = "Sync" | "Async";
 ```ts
 type FunctionQuery =
     | // Match class constructor
-    { className: string; index?: number }
+    { className: string; index?: number; isExportAlias?: boolean }
     | // Match class method
     {
         className: string;
         methodName: string;
         kind: FunctionKind;
         index?: number;
+        isExportAlias?: boolean;
     }
     | // Match method on objects
     { methodName: string; kind: FunctionKind; index?: number }
     | // Match standalone function
-    { functionName: string; kind: FunctionKind; index?: number }
+    { functionName: string; kind: FunctionKind; index?: number; isExportAlias?: boolean }
     | // Match arrow function or function expression
-    { expressionName: string; kind: FunctionKind; index?: number };
+    { expressionName: string; kind: FunctionKind; index?: number; isExportAlias?: boolean };
 ```
 
 #### **`ModuleMatcher`**

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ pub struct ModuleMatcher {
     /// The name of the module you want to match
     pub name: String,
     /// The semver range that you want to match
-    #[tsify(type = "string")]
+    #[cfg_attr(feature = "wasm", tsify(type = "string"))]
     pub version_range: Range,
     /// The path of the file you want to match from the module root
     pub file_path: PathBuf,

--- a/src/function_query.rs
+++ b/src/function_query.rs
@@ -2,6 +2,7 @@
  * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
  * This product includes software developed at Datadog (<https://www.datadoghq.com>/). Copyright 2025 Datadog, Inc.
  **/
+use std::collections::HashMap;
 use swc_core::ecma::ast::FnDecl;
 
 #[derive(Debug, Clone)]
@@ -53,12 +54,18 @@ pub enum FunctionQuery {
         #[cfg_attr(feature = "serde", serde(default))]
         #[cfg_attr(feature = "wasm", tsify(optional))]
         index: usize,
+        #[cfg_attr(feature = "serde", serde(default))]
+        #[cfg_attr(feature = "wasm", tsify(optional))]
+        is_export_alias: bool,
     },
     ClassConstructor {
         class_name: String,
         #[cfg_attr(feature = "serde", serde(default))]
         #[cfg_attr(feature = "wasm", tsify(optional))]
         index: usize,
+        #[cfg_attr(feature = "serde", serde(default))]
+        #[cfg_attr(feature = "wasm", tsify(optional))]
+        is_export_alias: bool,
     },
     ObjectMethod {
         method_name: String,
@@ -73,6 +80,9 @@ pub enum FunctionQuery {
         #[cfg_attr(feature = "serde", serde(default))]
         #[cfg_attr(feature = "wasm", tsify(optional))]
         index: usize,
+        #[cfg_attr(feature = "serde", serde(default))]
+        #[cfg_attr(feature = "wasm", tsify(optional))]
+        is_export_alias: bool,
     },
     FunctionExpression {
         expression_name: String,
@@ -80,6 +90,9 @@ pub enum FunctionQuery {
         #[cfg_attr(feature = "serde", serde(default))]
         #[cfg_attr(feature = "wasm", tsify(optional))]
         index: usize,
+        #[cfg_attr(feature = "serde", serde(default))]
+        #[cfg_attr(feature = "wasm", tsify(optional))]
+        is_export_alias: bool,
     },
 }
 
@@ -89,6 +102,7 @@ impl FunctionQuery {
         FunctionQuery::ClassConstructor {
             class_name: class_name.to_string(),
             index: 0,
+            is_export_alias: false,
         }
     }
 
@@ -99,6 +113,7 @@ impl FunctionQuery {
             method_name: method_name.to_string(),
             kind,
             index: 0,
+            is_export_alias: false,
         }
     }
 
@@ -117,6 +132,7 @@ impl FunctionQuery {
             function_name: function_name.to_string(),
             kind,
             index: 0,
+            is_export_alias: false,
         }
     }
 
@@ -126,7 +142,28 @@ impl FunctionQuery {
             expression_name: expression_name.to_string(),
             kind,
             index: 0,
+            is_export_alias: false,
         }
+    }
+
+    #[must_use]
+    pub fn as_export_alias(mut self) -> Self {
+        match &mut self {
+            FunctionQuery::ClassConstructor {
+                is_export_alias, ..
+            }
+            | FunctionQuery::ClassMethod {
+                is_export_alias, ..
+            }
+            | FunctionQuery::FunctionDeclaration {
+                is_export_alias, ..
+            }
+            | FunctionQuery::FunctionExpression {
+                is_export_alias, ..
+            } => *is_export_alias = true,
+            FunctionQuery::ObjectMethod { .. } => {}
+        }
+        self
     }
 
     pub(crate) fn kind(&self) -> &FunctionKind {
@@ -178,6 +215,40 @@ impl FunctionQuery {
             FunctionQuery::ClassConstructor { class_name, .. }
             | FunctionQuery::ClassMethod { class_name, .. } => Some(class_name),
             _ => None,
+        }
+    }
+
+    fn resolvable_name_mut(&mut self) -> Option<(&mut String, bool)> {
+        match self {
+            FunctionQuery::ClassConstructor {
+                class_name,
+                is_export_alias,
+                ..
+            }
+            | FunctionQuery::ClassMethod {
+                class_name,
+                is_export_alias,
+                ..
+            } => Some((class_name, *is_export_alias)),
+            FunctionQuery::FunctionDeclaration {
+                function_name,
+                is_export_alias,
+                ..
+            } => Some((function_name, *is_export_alias)),
+            FunctionQuery::FunctionExpression {
+                expression_name,
+                is_export_alias,
+                ..
+            } => Some((expression_name, *is_export_alias)),
+            FunctionQuery::ObjectMethod { .. } => None,
+        }
+    }
+
+    pub(crate) fn resolve_export_alias(&mut self, aliases: &HashMap<String, String>) {
+        if let Some((name, true)) = self.resolvable_name_mut() {
+            if let Some(local) = aliases.get(name.as_str()) {
+                name.clone_from(local);
+            }
         }
     }
 

--- a/src/instrumentation.rs
+++ b/src/instrumentation.rs
@@ -3,6 +3,7 @@
  * This product includes software developed at Datadog (<https://www.datadoghq.com>/). Copyright 2025 Datadog, Inc.
  **/
 use crate::config::InstrumentationConfig;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use swc_core::common::{Span, SyntaxContext};
 use swc_core::ecma::{
@@ -34,6 +35,7 @@ pub struct Instrumentation {
     is_correct_class: bool,
     has_injected: bool,
     module_version: Option<String>,
+    original_query_name: Option<String>,
 }
 
 impl Instrumentation {
@@ -45,11 +47,32 @@ impl Instrumentation {
             is_correct_class: false,
             has_injected: false,
             module_version: None,
+            original_query_name: None,
         }
     }
 
     pub fn set_module_version(&mut self, version: &str) {
         self.module_version = Some(version.to_string());
+    }
+
+    pub(crate) fn resolve_export_aliases(&mut self, aliases: &HashMap<String, String>) {
+        let original_name = self.config.function_query.name().to_string();
+        self.config.function_query.resolve_export_alias(aliases);
+        if self.config.function_query.name() != original_name {
+            self.original_query_name = Some(original_name);
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn query_display_name(&self) -> String {
+        match &self.original_query_name {
+            Some(original) => format!(
+                "{} (local name: {})",
+                original,
+                self.config.function_query.name()
+            ),
+            None => self.config.function_query.name().to_string(),
+        }
     }
 
     #[must_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
  * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
  * This product includes software developed at Datadog (<https://www.datadoghq.com>/). Copyright 2025 Datadog, Inc.
  **/
-use std::{error::Error, path::PathBuf, sync::Arc};
+use std::{collections::HashMap, error::Error, path::PathBuf, sync::Arc};
 use swc::{
     config::{IsModule, SourceMapsConfig},
     sourcemap::SourceMap,
@@ -28,8 +28,9 @@ use swc_core::{
     common::{comments::Comments, errors::ColorConfig, FileName, FilePathMapping},
     ecma::{
         ast::{
-            AssignExpr, ClassDecl, ClassExpr, ClassMethod, Constructor, EsVersion, FnDecl,
-            MethodProp, Module, Script, Str, VarDecl,
+            AssignExpr, ClassDecl, ClassExpr, ClassMethod, Constructor, EsVersion, ExportSpecifier,
+            FnDecl, MethodProp, Module, ModuleDecl, ModuleExportName, ModuleItem, Script, Str,
+            VarDecl,
         },
         visit::{VisitMut, VisitMutWith},
     },
@@ -70,6 +71,37 @@ pub struct TransformOutput {
     pub code: String,
     /// The sourcemap for the transformation (if generated)
     pub map: Option<String>,
+}
+
+fn module_export_name_to_string(name: &ModuleExportName) -> String {
+    match name {
+        ModuleExportName::Ident(ident) => ident.sym.to_string(),
+        ModuleExportName::Str(s) => s.value.to_string(),
+    }
+}
+
+/// Collects ESM named export aliases from a module.
+/// For `export { local as exported }`, maps `exported -> local`.
+/// Skips re-exports from other modules (i.e., `export { x } from 'other'`).
+fn collect_export_aliases(module: &Module) -> HashMap<String, String> {
+    let mut aliases = HashMap::new();
+    for item in &module.body {
+        if let ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) = item {
+            if named.src.is_some() {
+                continue;
+            }
+            for spec in &named.specifiers {
+                if let ExportSpecifier::Named(named_spec) = spec {
+                    if let Some(exported) = &named_spec.exported {
+                        let exported_name = module_export_name_to_string(exported);
+                        let local_name = module_export_name_to_string(&named_spec.orig);
+                        aliases.insert(exported_name, local_name);
+                    }
+                }
+            }
+        }
+    }
+    aliases
 }
 
 /// This struct is responsible for managing all instrumentations. It's created from a YAML string
@@ -149,7 +181,7 @@ impl InstrumentationVisitor {
                 if instr.has_injected() {
                     None
                 } else {
-                    Some(instr.config.function_query.name().to_string())
+                    Some(instr.query_display_name())
                 }
             })
             .collect();
@@ -279,6 +311,13 @@ macro_rules! visit_with_all_fn {
 
 impl VisitMut for InstrumentationVisitor {
     fn visit_mut_module(&mut self, item: &mut Module) {
+        let aliases = collect_export_aliases(item);
+        if !aliases.is_empty() {
+            for instr in &mut self.instrumentations {
+                instr.resolve_export_aliases(&aliases);
+            }
+        }
+
         let mut line = quote!(
             "import { tracingChannel as tr_ch_apm_tracingChannel } from 'dc';" as ModuleItem,
         );

--- a/tests/export_alias_class_mjs/mod.mjs
+++ b/tests/export_alias_class_mjs/mod.mjs
@@ -1,0 +1,11 @@
+/**
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2025 Datadog, Inc.
+ **/
+class J {
+  async fetch(url) {
+    return 42;
+  }
+}
+
+export { J as Undici };

--- a/tests/export_alias_class_mjs/mod.rs
+++ b/tests/export_alias_class_mjs/mod.rs
@@ -1,0 +1,16 @@
+use crate::common::*;
+use orchestrion_js::*;
+
+#[test]
+fn export_alias_class_mjs() {
+    transpile_and_test(
+        file!(),
+        true,
+        Config::new_single(InstrumentationConfig::new(
+            "Undici:fetch",
+            test_module_matcher(),
+            FunctionQuery::class_method("Undici", "fetch", FunctionKind::Async)
+                .as_export_alias(),
+        )),
+    );
+}

--- a/tests/export_alias_class_mjs/mod.rs
+++ b/tests/export_alias_class_mjs/mod.rs
@@ -9,8 +9,7 @@ fn export_alias_class_mjs() {
         Config::new_single(InstrumentationConfig::new(
             "Undici:fetch",
             test_module_matcher(),
-            FunctionQuery::class_method("Undici", "fetch", FunctionKind::Async)
-                .as_export_alias(),
+            FunctionQuery::class_method("Undici", "fetch", FunctionKind::Async).as_export_alias(),
         )),
     );
 }

--- a/tests/export_alias_class_mjs/test.mjs
+++ b/tests/export_alias_class_mjs/test.mjs
@@ -1,0 +1,16 @@
+/**
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2025 Datadog, Inc.
+ **/
+import { Undici } from './instrumented.mjs';
+import { assert, getContext } from '../common/preamble.js';
+const context = getContext('orchestrion:undici:Undici:fetch');
+const undici = new Undici();
+const result = await undici.fetch('https://example.com');
+assert.strictEqual(result, 42);
+assert.deepStrictEqual(context, {
+  start: true,
+  end: true,
+  asyncStart: 42,
+  asyncEnd: 42
+});

--- a/tests/export_alias_mjs/mod.mjs
+++ b/tests/export_alias_mjs/mod.mjs
@@ -1,0 +1,9 @@
+/**
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2025 Datadog, Inc.
+ **/
+async function f(url) {
+  return 42;
+}
+
+export { f as fetchAliased };

--- a/tests/export_alias_mjs/mod.rs
+++ b/tests/export_alias_mjs/mod.rs
@@ -1,0 +1,16 @@
+use crate::common::*;
+use orchestrion_js::*;
+
+#[test]
+fn export_alias_mjs() {
+    transpile_and_test(
+        file!(),
+        true,
+        Config::new_single(InstrumentationConfig::new(
+            "fetch_alias",
+            test_module_matcher(),
+            FunctionQuery::function_declaration("fetchAliased", FunctionKind::Async)
+                .as_export_alias(),
+        )),
+    );
+}

--- a/tests/export_alias_mjs/test.mjs
+++ b/tests/export_alias_mjs/test.mjs
@@ -1,0 +1,15 @@
+/**
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2025 Datadog, Inc.
+ **/
+import { fetchAliased } from './instrumented.mjs';
+import { assert, getContext } from '../common/preamble.js';
+const context = getContext('orchestrion:undici:fetch_alias');
+const result = await fetchAliased('https://example.com');
+assert.strictEqual(result, 42);
+assert.deepStrictEqual(context, {
+  start: true,
+  end: true,
+  asyncStart: 42,
+  asyncEnd: 42
+});

--- a/tests/index_cjs/mod.rs
+++ b/tests/index_cjs/mod.rs
@@ -14,6 +14,7 @@ fn index_cjs() {
                 method_name: "fetch".to_string(),
                 kind: FunctionKind::Async,
                 index: 2,
+                is_export_alias: false,
             },
         )),
     );

--- a/tests/instrumentor_test.rs
+++ b/tests/instrumentor_test.rs
@@ -12,6 +12,8 @@ mod constructor_mjs;
 mod decl_cjs;
 mod decl_mjs;
 mod decl_mjs_mismatched_type;
+mod export_alias_class_mjs;
+mod export_alias_mjs;
 mod expr_cjs;
 mod expr_mjs;
 mod index_cjs;


### PR DESCRIPTION
When trying to add instrumentation for https://github.com/google/adk-js, I ran into the problem where everything was minified in one big `index.js` file. By being able to adjust the orchestrion query to account for import aliases, I was able to add instrumentation successfully.

So for example something like `export { f as fetchAliased };`, we can query for `fetchAliased` with `isExportAlias: true`, and it would patch the `f` identifier.

### AI Summary

Here's a summary of the changes on the `abhi-export-alias` branch (single commit `e089f5e`):

**Feature: Support for matching export aliases in ESM modules**

When a module re-exports a local symbol under a different name (e.g., `export { localFn as publicFn }`), the instrumentor previously couldn't match the exported name to the local declaration. This branch adds that capability:

1. **New `collect_export_aliases` function** (`src/lib.rs`) — Scans a module's named exports and builds a `HashMap<exported_name, local_name>` for any aliased exports (skipping re-exports from other modules).

2. **`is_export_alias` flag on `FunctionQuery` variants** (`src/function_query.rs`) — `FunctionDeclaration`, `FunctionExpression`, `ClassConstructor`, and `ClassMethod` now carry an optional `is_export_alias` boolean. When true, the query name is treated as an exported alias that needs resolution.

3. **Alias resolution** — `FunctionQuery::resolve_export_alias()` replaces the query's name with the local name using the alias map.

4. **Integration in `visit_mut_module`** — Before visiting the module body, the visitor collects export aliases and resolves them across all instrumentations.

5. **Minor fix** — The `tsify` attribute on `ModuleMatcher::version_range` is now gated behind `#[cfg_attr(feature = "wasm", ...)]` to avoid issues when the wasm feature is disabled.

6. **Tests** — Two new test suites (`export_alias_mjs`, `export_alias_class_mjs`) verify that functions and classes exported under aliases are correctly instrumented.